### PR TITLE
#32 初回ログイン時のセットアップ状態確認機能を実装

### DIFF
--- a/Packages/Core/Package.resolved
+++ b/Packages/Core/Package.resolved
@@ -1,0 +1,258 @@
+{
+  "originHash" : "a2b7a063d63968f3c5e0eb3ca6a4aa9946638adc4b6d040325ac2e98ea234217",
+  "pins" : [
+    {
+      "identity" : "abseil-cpp-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/abseil-cpp-binary.git",
+      "state" : {
+        "revision" : "bbe8b69694d7873315fd3a4ad41efe043e1c07c5",
+        "version" : "1.2024072200.0"
+      }
+    },
+    {
+      "identity" : "app-check",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/app-check.git",
+      "state" : {
+        "revision" : "61b85103a1aeed8218f17c794687781505fbbef5",
+        "version" : "11.2.0"
+      }
+    },
+    {
+      "identity" : "combine-schedulers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/combine-schedulers",
+      "state" : {
+        "revision" : "5928286acce13def418ec36d05a001a9641086f2",
+        "version" : "1.0.3"
+      }
+    },
+    {
+      "identity" : "firebase-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/firebase-ios-sdk.git",
+      "state" : {
+        "revision" : "45d327fcbe7793747295346c2209ad419bdead74",
+        "version" : "11.14.0"
+      }
+    },
+    {
+      "identity" : "google-ads-on-device-conversion-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk",
+      "state" : {
+        "revision" : "428d8bb138e00f9a3f4f61cc6cd8863607524f65",
+        "version" : "2.1.0"
+      }
+    },
+    {
+      "identity" : "googleappmeasurement",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleAppMeasurement.git",
+      "state" : {
+        "revision" : "406f72d0d5e9445fd1cf782db3e9e338cee2bed4",
+        "version" : "11.14.0"
+      }
+    },
+    {
+      "identity" : "googledatatransport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleDataTransport.git",
+      "state" : {
+        "revision" : "617af071af9aa1d6a091d59a202910ac482128f9",
+        "version" : "10.1.0"
+      }
+    },
+    {
+      "identity" : "googleutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleUtilities.git",
+      "state" : {
+        "revision" : "60da361632d0de02786f709bdc0c4df340f7613e",
+        "version" : "8.1.0"
+      }
+    },
+    {
+      "identity" : "grpc-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/grpc-binary.git",
+      "state" : {
+        "revision" : "cc0001a0cf963aa40501d9c2b181e7fc9fd8ec71",
+        "version" : "1.69.0"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "c756a29784521063b6a1202907e2cc47f41b667c",
+        "version" : "4.5.0"
+      }
+    },
+    {
+      "identity" : "interop-ios-for-google-sdks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
+      "state" : {
+        "revision" : "040d087ac2267d2ddd4cca36c757d1c6a05fdbfe",
+        "version" : "101.0.0"
+      }
+    },
+    {
+      "identity" : "leveldb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/leveldb.git",
+      "state" : {
+        "revision" : "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
+        "version" : "1.22.5"
+      }
+    },
+    {
+      "identity" : "nanopb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/nanopb.git",
+      "state" : {
+        "revision" : "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
+        "version" : "2.30910.0"
+      }
+    },
+    {
+      "identity" : "promises",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/promises.git",
+      "state" : {
+        "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
+        "version" : "2.4.0"
+      }
+    },
+    {
+      "identity" : "swift-case-paths",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-case-paths",
+      "state" : {
+        "revision" : "9810c8d6c2914de251e072312f01d3bf80071852",
+        "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-clocks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-clocks",
+      "state" : {
+        "revision" : "cc46202b53476d64e824e0b6612da09d84ffde8e",
+        "version" : "1.0.6"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections",
+      "state" : {
+        "revision" : "c1805596154bb3a265fd91b8ac0c4433b4348fb0",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-composable-architecture",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-composable-architecture",
+      "state" : {
+        "revision" : "6574de2396319a58e86e2178577268cb4aeccc30",
+        "version" : "1.20.2"
+      }
+    },
+    {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "82a4ae7170d98d8538ec77238b7eb8e7199ef2e8",
+        "version" : "1.3.1"
+      }
+    },
+    {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "82645ec760917961cfa08c9c0c7104a57a0fa4b1",
+        "version" : "1.3.3"
+      }
+    },
+    {
+      "identity" : "swift-dependencies",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-dependencies",
+      "state" : {
+        "revision" : "4c90d6b2b9bf0911af87b103bb40f41771891596",
+        "version" : "1.9.2"
+      }
+    },
+    {
+      "identity" : "swift-identified-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-identified-collections",
+      "state" : {
+        "revision" : "322d9ffeeba85c9f7c4984b39422ec7cc3c56597",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-navigation",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-navigation",
+      "state" : {
+        "revision" : "ae208d1a5cf33aee1d43734ea780a09ada6e2a21",
+        "version" : "2.3.1"
+      }
+    },
+    {
+      "identity" : "swift-perception",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-perception",
+      "state" : {
+        "revision" : "d924c62a70fca5f43872f286dbd7cef0957f1c01",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "102a647b573f60f73afdce5613a51d71349fe507",
+        "version" : "1.30.0"
+      }
+    },
+    {
+      "identity" : "swift-sharing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-sharing",
+      "state" : {
+        "revision" : "75e846ee3159dc75b3a29bfc24b6ce5a557ddca9",
+        "version" : "2.5.2"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
+        "version" : "601.0.1"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "39de59b2d47f7ef3ca88a039dff3084688fe27f4",
+        "version" : "1.5.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Packages/Core/Package.swift
+++ b/Packages/Core/Package.swift
@@ -7,6 +7,7 @@ let package = Package(
     name: "Core",
     platforms: [
         .iOS("26.0"),
+        .macOS("10.15"),
     ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.
@@ -58,6 +59,7 @@ let package = Package(
                 .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
                 .product(name: "FirebaseAuth", package: "firebase-ios-sdk"),
                 .product(name: "FirebaseCore", package: "firebase-ios-sdk"),
+                .product(name: "FirebaseFirestore", package: "firebase-ios-sdk"),
             ]
         ),
 

--- a/Packages/Core/Package.swift
+++ b/Packages/Core/Package.swift
@@ -16,6 +16,10 @@ let package = Package(
             targets: ["AuthClient"]),
 
         .library(
+            name: "UserClient",
+            targets: ["UserClient"]),
+
+        .library(
             name: "Entity",
             targets: ["Entity"]),
 
@@ -59,6 +63,14 @@ let package = Package(
                 .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
                 .product(name: "FirebaseAuth", package: "firebase-ios-sdk"),
                 .product(name: "FirebaseCore", package: "firebase-ios-sdk"),
+            ]
+        ),
+
+        .target(
+            name: "UserClient",
+            dependencies: [
+                "Entity",
+                .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
                 .product(name: "FirebaseFirestore", package: "firebase-ios-sdk"),
             ]
         ),
@@ -111,6 +123,7 @@ let package = Package(
                 "Entity",
                 "AuthFeature",
                 "MainTabFeature",
+                "UserClient",
                 "UIComponents",
                 .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
             ],

--- a/Packages/Core/Sources/AuthClient/AuthClient.swift
+++ b/Packages/Core/Sources/AuthClient/AuthClient.swift
@@ -2,7 +2,6 @@ import ComposableArchitecture
 import Entity
 import FirebaseAuth
 import FirebaseCore
-import FirebaseFirestore
 
 public struct AuthClient: Sendable {
     public static func configure() {
@@ -14,7 +13,6 @@ public struct AuthClient: Sendable {
     public var signOut: @Sendable () throws -> Void
     public var appleSignIn: @Sendable () async throws -> Entity.User.ID
     public var sendPasswordResetEmail: @Sendable (EMail) async throws -> Void
-    public var getUserSetupStatus: @Sendable (Entity.User.ID) async throws -> Bool
 
     public init(
         autoLogin: @escaping @Sendable () -> Entity.User.ID?,
@@ -22,8 +20,7 @@ public struct AuthClient: Sendable {
         signUp: @escaping @Sendable (EMail, String) async throws -> Entity.User.ID,
         signOut: @escaping @Sendable () throws -> Void,
         appleSignIn: @escaping @Sendable () async throws -> Entity.User.ID,
-        sendPasswordResetEmail: @escaping @Sendable (EMail) async throws -> Void,
-        getUserSetupStatus: @escaping @Sendable (Entity.User.ID) async throws -> Bool
+        sendPasswordResetEmail: @escaping @Sendable (EMail) async throws -> Void
     ) {
         self.autoLogin = autoLogin
         self.login = login
@@ -31,7 +28,6 @@ public struct AuthClient: Sendable {
         self.signOut = signOut
         self.appleSignIn = appleSignIn
         self.sendPasswordResetEmail = sendPasswordResetEmail
-        self.getUserSetupStatus = getUserSetupStatus
     }
 }
 
@@ -81,23 +77,6 @@ extension AuthClient: DependencyKey {
                 } catch {
                     throw AuthError(from: error)
                 }
-            },
-            getUserSetupStatus: { userID in
-                do {
-                    let db = Firestore.firestore()
-                    let userDoc = try await db.collection("users").document(userID.rawValue).getDocument()
-                    
-                    guard userDoc.exists,
-                          let data = userDoc.data(),
-                          let isSetupCompleted = data["isSetupCompleted"] as? Bool else {
-                        // ユーザードキュメントが存在しない場合は未セットアップとみなす
-                        return false
-                    }
-                    
-                    return isSetupCompleted
-                } catch {
-                    throw AuthError(from: error)
-                }
             }
         )
     }
@@ -123,10 +102,6 @@ extension AuthClient: DependencyKey {
             },
             sendPasswordResetEmail: { _ in
                 // Do nothing
-            },
-            getUserSetupStatus: { _ in
-                try await Task.sleep(for: .seconds(0.5))
-                return false // プレビューでは常に未セットアップ
             }
         )
     }

--- a/Packages/Core/Sources/AuthClient/AuthClient.swift
+++ b/Packages/Core/Sources/AuthClient/AuthClient.swift
@@ -2,6 +2,7 @@ import ComposableArchitecture
 import Entity
 import FirebaseAuth
 import FirebaseCore
+import FirebaseFirestore
 
 public struct AuthClient: Sendable {
     public static func configure() {
@@ -13,6 +14,7 @@ public struct AuthClient: Sendable {
     public var signOut: @Sendable () throws -> Void
     public var appleSignIn: @Sendable () async throws -> Entity.User.ID
     public var sendPasswordResetEmail: @Sendable (EMail) async throws -> Void
+    public var getUserSetupStatus: @Sendable (Entity.User.ID) async throws -> Bool
 
     public init(
         autoLogin: @escaping @Sendable () -> Entity.User.ID?,
@@ -20,7 +22,8 @@ public struct AuthClient: Sendable {
         signUp: @escaping @Sendable (EMail, String) async throws -> Entity.User.ID,
         signOut: @escaping @Sendable () throws -> Void,
         appleSignIn: @escaping @Sendable () async throws -> Entity.User.ID,
-        sendPasswordResetEmail: @escaping @Sendable (EMail) async throws -> Void
+        sendPasswordResetEmail: @escaping @Sendable (EMail) async throws -> Void,
+        getUserSetupStatus: @escaping @Sendable (Entity.User.ID) async throws -> Bool
     ) {
         self.autoLogin = autoLogin
         self.login = login
@@ -28,6 +31,7 @@ public struct AuthClient: Sendable {
         self.signOut = signOut
         self.appleSignIn = appleSignIn
         self.sendPasswordResetEmail = sendPasswordResetEmail
+        self.getUserSetupStatus = getUserSetupStatus
     }
 }
 
@@ -77,6 +81,23 @@ extension AuthClient: DependencyKey {
                 } catch {
                     throw AuthError(from: error)
                 }
+            },
+            getUserSetupStatus: { userID in
+                do {
+                    let db = Firestore.firestore()
+                    let userDoc = try await db.collection("users").document(userID.rawValue).getDocument()
+                    
+                    guard userDoc.exists,
+                          let data = userDoc.data(),
+                          let isSetupCompleted = data["isSetupCompleted"] as? Bool else {
+                        // ユーザードキュメントが存在しない場合は未セットアップとみなす
+                        return false
+                    }
+                    
+                    return isSetupCompleted
+                } catch {
+                    throw AuthError(from: error)
+                }
             }
         )
     }
@@ -102,6 +123,10 @@ extension AuthClient: DependencyKey {
             },
             sendPasswordResetEmail: { _ in
                 // Do nothing
+            },
+            getUserSetupStatus: { _ in
+                try await Task.sleep(for: .seconds(0.5))
+                return false // プレビューでは常に未セットアップ
             }
         )
     }

--- a/Packages/Core/Sources/Entity/User.swift
+++ b/Packages/Core/Sources/Entity/User.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 public struct User: Sendable, Identifiable {
     public struct ID: Sendable, Hashable, Codable, RawRepresentable, ExpressibleByStringLiteral {
         public let rawValue: String
@@ -10,9 +12,13 @@ public struct User: Sendable, Identifiable {
     }
     public var id: ID
     public var name: String
+    public var isSetupCompleted: Bool
+    public var setupCompletedAt: Date?
 
-    public init(id: ID, name: String) {
+    public init(id: ID, name: String, isSetupCompleted: Bool = false, setupCompletedAt: Date? = nil) {
         self.id = id
         self.name = name
+        self.isSetupCompleted = isSetupCompleted
+        self.setupCompletedAt = setupCompletedAt
     }
 }

--- a/Packages/Core/Sources/Features/ProductAppFeature/ProductAppReducer.swift
+++ b/Packages/Core/Sources/Features/ProductAppFeature/ProductAppReducer.swift
@@ -11,6 +11,7 @@ public struct ProductAppReducer: Sendable {
     public struct State: Equatable {
         var mainTab: MainTabReducer.State?
         var loading: Bool = false
+        var checkingSetupStatus: Bool = false
         @Presents var login: LoginReducer.State?
         public init() {}
     }
@@ -20,6 +21,8 @@ public struct ProductAppReducer: Sendable {
         case login(PresentationAction<LoginReducer.Action>)
         case loginButtonTapped
         case autoLogin
+        case checkSetupStatus(Entity.User.ID)
+        case setupStatusReceived(Bool, Entity.User.ID)
     }
 
     @Dependency(\.authClient) var authClient
@@ -31,7 +34,9 @@ public struct ProductAppReducer: Sendable {
             switch action {
             case .autoLogin:
                 if let userID = authClient.autoLogin() {
-                    state.mainTab = .init(userID: userID)
+                    return .run { send in
+                        await send(.checkSetupStatus(userID))
+                    }
                 }
                 return .none
             case .loginButtonTapped:
@@ -39,18 +44,41 @@ public struct ProductAppReducer: Sendable {
                 return .none
             case .login(.presented(.loginSucceeded(let userID))):
                 state.login = nil
-                state.mainTab = .init(userID: userID)
-                return .none
+                return .run { send in
+                    await send(.checkSetupStatus(userID))
+                }
             case .login(.presented(.signUp(.presented(.signUpSucceeded(let userID))))):
                 state.login = nil
-                state.mainTab = .init(userID: userID)
+                return .run { send in
+                    await send(.checkSetupStatus(userID))
+                }
+            case .checkSetupStatus(let userID):
+                state.checkingSetupStatus = true
+                return .run { send in
+                    do {
+                        let isSetupCompleted = try await authClient.getUserSetupStatus(userID)
+                        await send(.setupStatusReceived(isSetupCompleted, userID))
+                    } catch {
+                        // エラー時は一旦セットアップ完了とみなしてMainTabへ遷移
+                        await send(.setupStatusReceived(true, userID))
+                    }
+                }
+            case .setupStatusReceived(let isSetupCompleted, let userID):
+                state.checkingSetupStatus = false
+                
+                if isSetupCompleted {
+                    // セットアップ完了済みの場合はMainTabへ遷移
+                    state.mainTab = .init(userID: userID)
+                } else {
+                    // 未セットアップの場合は将来的にSetupFeatureへ遷移
+                    // TODO: SetupFeature実装後に変更
+                    state.mainTab = .init(userID: userID)
+                }
                 return .none
             case .login:
                 return .none
             case .mainTab(.settings(.logout)):
                 state.mainTab = nil
-                return .none
-            case .mainTab:
                 return .none
             }
         }

--- a/Packages/Core/Sources/Features/ProductAppFeature/ProductAppReducer.swift
+++ b/Packages/Core/Sources/Features/ProductAppFeature/ProductAppReducer.swift
@@ -1,6 +1,7 @@
 import AuthFeature
 import ComposableArchitecture
 import AuthClient
+import UserClient
 import Entity
 import MainTabFeature
 import SwiftUI
@@ -26,6 +27,7 @@ public struct ProductAppReducer: Sendable {
     }
 
     @Dependency(\.authClient) var authClient
+    @Dependency(\.userClient) var userClient
 
     public init() {}
 
@@ -56,7 +58,7 @@ public struct ProductAppReducer: Sendable {
                 state.checkingSetupStatus = true
                 return .run { send in
                     do {
-                        let isSetupCompleted = try await authClient.getUserSetupStatus(userID)
+                        let isSetupCompleted = try await userClient.getUserSetupStatus(userID)
                         await send(.setupStatusReceived(isSetupCompleted, userID))
                     } catch {
                         // エラー時は一旦セットアップ完了とみなしてMainTabへ遷移

--- a/Packages/Core/Sources/Features/ProductAppFeature/ProductAppReducer.swift
+++ b/Packages/Core/Sources/Features/ProductAppFeature/ProductAppReducer.swift
@@ -80,6 +80,8 @@ public struct ProductAppReducer: Sendable {
             case .mainTab(.settings(.logout)):
                 state.mainTab = nil
                 return .none
+            case .mainTab:
+                return .none
             }
         }
         .ifLet(\.mainTab, action: \.mainTab) {

--- a/Packages/Core/Sources/Features/ProductAppFeature/ProductAppView.swift
+++ b/Packages/Core/Sources/Features/ProductAppFeature/ProductAppView.swift
@@ -19,8 +19,14 @@ public struct ProductAppView: View {
                     .opacity(0.3)
                     .ignoresSafeArea()
                     .overlay {
-                        if store.loading {
-                            ProgressView()
+                        if store.loading || store.checkingSetupStatus {
+                            VStack {
+                                ProgressView()
+                                Text(store.checkingSetupStatus ? "セットアップ状態を確認中..." : "読み込み中...")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                                    .padding(.top, 8)
+                            }
                         } else {
                             Button("ログイン") {
                                 store.send(.loginButtonTapped)

--- a/Packages/Core/Sources/UserClient/UserClient.swift
+++ b/Packages/Core/Sources/UserClient/UserClient.swift
@@ -1,0 +1,69 @@
+import ComposableArchitecture
+import Entity
+import FirebaseFirestore
+
+public struct UserClient: Sendable {
+    public var getUserSetupStatus: @Sendable (Entity.User.ID) async throws -> Bool
+    
+    public init(
+        getUserSetupStatus: @escaping @Sendable (Entity.User.ID) async throws -> Bool
+    ) {
+        self.getUserSetupStatus = getUserSetupStatus
+    }
+}
+
+public struct UserClientError: Error, Equatable {
+    public let localizedDescription: String
+    
+    public init(from error: Error) {
+        self.localizedDescription = error.localizedDescription
+    }
+    
+    public init(message: String) {
+        self.localizedDescription = message
+    }
+}
+
+extension UserClient: DependencyKey {
+    public static var liveValue: UserClient {
+        UserClient(
+            getUserSetupStatus: { userID in
+                do {
+                    let db = Firestore.firestore()
+                    let userDoc = try await db.collection("users").document(userID.rawValue).getDocument()
+                    
+                    guard userDoc.exists,
+                          let data = userDoc.data(),
+                          let isSetupCompleted = data["isSetupCompleted"] as? Bool else {
+                        // ユーザードキュメントが存在しない場合は未セットアップとみなす
+                        return false
+                    }
+                    
+                    return isSetupCompleted
+                } catch {
+                    throw UserClientError(from: error)
+                }
+            }
+        )
+    }
+    
+    public static var previewValue: UserClient {
+        UserClient(
+            getUserSetupStatus: { _ in
+                try await Task.sleep(for: .seconds(0.5))
+                return false // プレビューでは常に未セットアップ
+            }
+        )
+    }
+}
+
+extension DependencyValues {
+    public var userClient: UserClient {
+        get {
+            self[UserClient.self]
+        }
+        set {
+            self[UserClient.self] = newValue
+        }
+    }
+}


### PR DESCRIPTION
## 概要
Issue #32 に対応し、ユーザーがログイン後にアカウントのセットアップ状態を確認し、適切な画面へルーティングする機能を実装しました。

## 実装内容

### 1. User Entity拡張
- `isSetupCompleted: Bool` フィールドを追加
- `setupCompletedAt: Date?` フィールドを追加（セットアップ完了日時記録用）

### 2. AuthClient機能追加
- `getUserSetupStatus(userID)` 関数を追加
- Firestoreからユーザー情報を取得し、セットアップ状態を確認
- エラー処理とプレビュー用モック実装

### 3. ProductAppFeature更新
- `checkingSetupStatus` 状態を追加
- ログイン/サインアップ成功後に自動でセットアップ状態確認
- セットアップ確認中のローディング表示を追加

### 4. 技術的対応
- Package.swiftにmacOS 10.15プラットフォーム対応追加
- FirebaseFirestore依存関係追加

## 現在の動作
- ログイン/サインアップ後、Firestoreでセットアップ状態を確認
- 現在は状態に関わらずMainTabFeatureに遷移
- SetupFeature実装後（Issue #33）に未セットアップ時の遷移先を変更予定

## Test plan
- [ ] ログイン後にセットアップ状態確認が実行されること
- [ ] Firestoreからセットアップ状態が正しく取得されること
- [ ] ネットワークエラー時の適切なフォールバック動作
- [ ] UI上でセットアップ確認中の表示が正しく表示されること

## 関連Issue
- Closes #32
- Related: #33 (SetupFeature実装), #34 (Firestore保存処理)

🤖 Generated with [Claude Code](https://claude.ai/code)